### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/src/main/java/org/apache/maven/plugin/coreit/ResolveOneDependencyMojo.java
+++ b/core-it-support/core-it-plugins/maven-it-plugin-dependency-resolution/src/main/java/org/apache/maven/plugin/coreit/ResolveOneDependencyMojo.java
@@ -170,11 +170,11 @@ public class ResolveOneDependencyMojo
                     File file = a.getFile();
                     if ( file == null )
                     {
-                        getLog().info( " RESOLVE-ONE-DEPENDENCY " + a.toString() + " $ NO-FILE" );
+                        getLog().info( " RESOLVE-ONE-DEPENDENCY " + a  + " $ NO-FILE" );
                     }
                     else
                     {
-                        getLog().info( " RESOLVE-ONE-DEPENDENCY " + a.toString() + " $ " + file.getAbsolutePath() );
+                        getLog().info( " RESOLVE-ONE-DEPENDENCY " + a  + " $ " + file.getAbsolutePath() );
                     }
                     return;
                 }


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:-711012573 -->
<!-- fingerprint:-652608329 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (2)
